### PR TITLE
Do not require SSL certificate if verify is false

### DIFF
--- a/esp_mqtt.c
+++ b/esp_mqtt.c
@@ -115,8 +115,8 @@ bool esp_mqtt_tls(bool enable, bool verify, const uint8_t *ca_buf, size_t ca_len
   }
 
   // check ca certificate
-  if (!ca_buf || ca_len <= 0) {
-    ESP_LOGE(ESP_MQTT_LOG_TAG, "esp_mqtt_tls: ca_buf must be not NULL.");
+  if (verify && (!ca_buf || ca_len <= 0)) {
+    ESP_LOGE(ESP_MQTT_LOG_TAG, "esp_mqtt_tls: ca_buf must be not NULL when verify is enabled.");
     ESP_MQTT_UNLOCK_MAIN();
     return false;
   }

--- a/esp_tls_lwmqtt.c
+++ b/esp_tls_lwmqtt.c
@@ -24,9 +24,11 @@ lwmqtt_err_t esp_tls_lwmqtt_network_connect(esp_tls_lwmqtt_network_t *network, c
   }
 
   // parse ca certificate
-  ret = mbedtls_x509_crt_parse(&network->cacert, network->ca_buf, network->ca_len);
-  if (ret != 0) {
-    return LWMQTT_NETWORK_FAILED_CONNECT;
+  if (network->ca_buf) {
+    ret = mbedtls_x509_crt_parse(&network->cacert, network->ca_buf, network->ca_len);
+    if (ret != 0) {
+      return LWMQTT_NETWORK_FAILED_CONNECT;
+    }
   }
 
   // connect socket
@@ -43,7 +45,9 @@ lwmqtt_err_t esp_tls_lwmqtt_network_connect(esp_tls_lwmqtt_network_t *network, c
   }
 
   // set ca certificate
-  mbedtls_ssl_conf_ca_chain(&network->conf, &network->cacert, NULL);
+  if (network->ca_buf) {
+    mbedtls_ssl_conf_ca_chain(&network->conf, &network->cacert, NULL);
+  }
 
   // set auth mode
   mbedtls_ssl_conf_authmode(&network->conf, (network->verify) ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_NONE);


### PR DESCRIPTION
If we don't verify the certificate, no need to require the user to provide one. This change will enable connections to SSL brokers without using a certificate, if verification is disabled.